### PR TITLE
Port details fix

### DIFF
--- a/napalm_optiswitch/utils/textfsm_templates/show_port_details.tpl
+++ b/napalm_optiswitch/utils/textfsm_templates/show_port_details.tpl
@@ -6,7 +6,7 @@ Value ActualSpeed (\d+ [MG]bps)
 
 Start
   ^Port ${Port} details:
-  ^Description\s+: <${Description}>
+  ^Description\s+: ${Description}
   ^Link\s+: ${LinkState}
   ^Actual speed\s+:\s+${ActualSpeed}
   ^State\s+: ${AdminState} -> Record


### PR DESCRIPTION
Description isn't always surrounded  by <>, not sure if this is part of the design of the devices, or version dependent