### PR TITLE
Get interface Mode

### DIFF
--- a/napalm_optiswitch/optiswitch.py
+++ b/napalm_optiswitch/optiswitch.py
@@ -137,6 +137,17 @@ class OptiswitchDriver(NetworkDriver):
             item['vif']: {'ipv4:': [item['ipaddress']]} for item in info
         }
 
+    def get_interfaces_mode(self):
+        """ Return data on which interfaces are tagged/untagged """
+        info = textfsm_extractor(
+            self, "show_port_details", self._send_command('show port details')
+        )
+
+        return  {
+            'untagged': [i['port'] for i in info if i['outboundtagged'] == 'untagged'],
+            'tagged': [i['port'] for i in info if i['outboundtagged'] == 'tagged'],
+        }
+
     def open(self):
         """Implement the NAPALM method open (mandatory)"""
         device_type = 'mrv_optiswitch'

--- a/napalm_optiswitch/utils/textfsm_templates/show_port_details.tpl
+++ b/napalm_optiswitch/utils/textfsm_templates/show_port_details.tpl
@@ -3,10 +3,12 @@ Value LinkState (ON|OFF)
 Value AdminState (ENABLE|DISABLE)
 Value Port (\d+)
 Value ActualSpeed (\d+ [MG]bps)
+Value OutBoundTagged (\w+)
 
 Start
   ^Port ${Port} details:
   ^Description\s+: <${Description}>
   ^Link\s+: ${LinkState}
   ^Actual speed\s+:\s+${ActualSpeed}
-  ^State\s+: ${AdminState} -> Record
+  ^State\s+: ${AdminState}
+  ^OutBound Tagged\s+: ${OutBoundTagged} -> Record


### PR DESCRIPTION
This gets the interface mode, not standard napalm getter, but used to get what interfaces are in tagged mode versus untagged mode.